### PR TITLE
[DOP-13337] Add Pydantic v2 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,13 +17,19 @@ env:
 
 jobs:
   tests:
-    name: Run ${{ matrix.mark }} tests (Python ${{ matrix.python-version }} on ${{ matrix.os }})
+    name: Run tests (Python ${{ matrix.python-version }}, Pydantic ${{ matrix.pydantic-version }}, ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.7', '3.12']
-        os: [ubuntu-latest]
+        include:
+          - python-version: '3.7'
+            pydantic-version: '1'
+            os: ubuntu-latest
+
+          - python-version: '3.12'
+            pydantic-version: '2'
+            os: ubuntu-latest
 
     steps:
       - name: Checkout code
@@ -47,10 +53,10 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-python-${{ matrix.python-version }}-tests-${{ hashFiles('requirements*.txt') }}
+          key: ${{ runner.os }}-python-${{ matrix.python-version }}-pydantic-${{ matrix.pydantic-version}}-tests-${{ hashFiles('requirements*.txt') }}
           restore-keys: |
-            ${{ runner.os }}-python-${{ matrix.python-version }}-tests-${{ hashFiles('requirements*.txt') }}
-            ${{ runner.os }}-python-${{ matrix.python-version }}-tests-
+            ${{ runner.os }}-python-${{ matrix.python-version }}-pydantic-${{ matrix.pydantic-version}}-tests-${{ hashFiles('requirements*.txt') }}
+            ${{ runner.os }}-python-${{ matrix.python-version }}-pydantic-${{ matrix.pydantic-version}}-tests-
             ${{ runner.os }}-python
             ${{ runner.os }}-
 
@@ -58,7 +64,7 @@ jobs:
         run: python -m pip install --upgrade pip setuptools wheel
 
       - name: Install dependencies
-        run: pip install -I -r requirements.txt -r requirements-test.txt
+        run: pip install -I -r requirements.txt -r requirements-test.txt "pydantic==${{ matrix.pydantic-version }}.*"
 
       - name: Build package
         run: |
@@ -68,6 +74,7 @@ jobs:
       - name: Run tests
         run: |
           mkdir reports/ || echo "Directory exists"
+          # required to register package in etl-entities
           pip install -e . --no-build-isolation
           source .env.local
           ./run_tests.sh
@@ -75,7 +82,7 @@ jobs:
       - name: Upload coverage results
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-${{ matrix.python-version }}-os-${{ matrix.os }}
+          name: coverage-python-${{ matrix.python-version }}-pydantic-${{ matrix.pydantic-version }}-os-${{ matrix.os }}
           path: reports/*
 
       - name: Shutdown Backend Container

--- a/conftest.py
+++ b/conftest.py
@@ -138,7 +138,7 @@ def ensure_namespace():
     )
 
     try:
-        store._client.create_namespace(NamespaceCreateRequestV1(name=HORIZON_NAMESPACE))  # noqa: WPS437
+        store.client.create_namespace(NamespaceCreateRequestV1(name=HORIZON_NAMESPACE))  # noqa: WPS437
     except HTTPError:
         # exception: 409 Client Error: Conflict for url: http://horizon/v1/namespaces/ - namespace already exists
         pass

--- a/docs/changelog/next_release/14.feature.rst
+++ b/docs/changelog/next_release/14.feature.rst
@@ -1,0 +1,1 @@
+Add Pydantic v2 support.

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,4 +1,4 @@
-autodoc_pydantic<2
+autodoc_pydantic
 furo
 numpydoc
 sphinx

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 data-horizon[client-sync]>=0.0.8,<0.1
-etl-entities>=2.1.0,<2.3.0
+etl-entities>=2.1.0,<2.4.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -188,7 +188,9 @@ ignore =
 # RST213: Inline emphasis start-string without end-string.
     RST213,
 # RST307: Error in "code" directive
-    RST307
+    RST307,
+# N805 first argument of a method should be named 'self'
+    N805
 
 
 # http://flake8.pycqa.org/en/latest/user/options.html?highlight=per-file-ignores#cmdoption-flake8-per-file-ignores


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/horizon-hwm-store/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

<!-- Please give a short summary of the changes. -->

Allow using horizon-hwm-store with both Pydantic v1 and v2 (thanks to etl-entities 2.3 release). Because Horizon client is inherited from `pydantic.BaseModel` and not `pydantic.v1.BaseModel`, this introduced few quirks to validation.

Added tests for both Pydantic versions to CI workflow.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [X] Unit and integration tests for the changes exist
* [ ] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [X] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/horizon-hwm-store/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.
